### PR TITLE
Allow icons in FAQ tab titles and remove shadows

### DIFF
--- a/sections/section-faq-tabs.liquid
+++ b/sections/section-faq-tabs.liquid
@@ -4,16 +4,13 @@
   assign animation_anchor = '#FaqTabs--' | append: section.id
 
   assign tabs_string = ''
-  assign icons_string = ''
   for block in section.blocks
     assign t = block.settings.tab | strip
     unless tabs_string contains t
       assign tabs_string = tabs_string | append: t | append: '||'
-      assign icons_string = icons_string | append: block.settings.tab_icon | append: '||'
     endunless
   endfor
   assign tabs = tabs_string | split: '||' | compact
-  assign tab_icons = icons_string | split: '||'
 -%}
 
 {%- if section.blocks.size > 0 -%}
@@ -202,6 +199,15 @@
         <faq-tabs class="faq-tabs" data-tabs-holder>
           <ul class="faq-tabs__head" role="tablist">
             {%- for tab in tabs -%}
+              {%- assign tab_icon = '' -%}
+              {%- assign tab_display = 'both' -%}
+              {%- for block in section.blocks -%}
+                {%- if block.settings.tab == tab -%}
+                  {%- assign tab_icon = block.settings.tab_icon -%}
+                  {%- assign tab_display = block.settings.tab_display | default: 'both' -%}
+                  {%- break -%}
+                {%- endif -%}
+              {%- endfor -%}
               <li
                 class="tab-link tab-link-{{ forloop.index0 }}{% if forloop.first %} current{% endif %}"
                 data-tab="{{ forloop.index0 }}"
@@ -210,11 +216,10 @@
                 aria-selected="{% if forloop.first %}true{% else %}false{% endif %}"
                 aria-controls="panel-{{ section.id }}-{{ forloop.index0 }}"
                 tabindex="0">
-                {%- assign tab_icon = tab_icons[forloop.index0] -%}
-                {%- if tab_icon != blank -%}
+                {%- if tab_display != 'title' and tab_icon != blank -%}
                   <img class="tab-link__icon" src="{{ tab_icon | image_url: width: 24 }}" alt="{{ tab | escape }}">
                 {%- endif -%}
-                {%- if tab != blank -%}
+                {%- if tab_display != 'image' and tab != blank -%}
                   <span>{{ tab }}</span>
                 {%- endif -%}
               </li>
@@ -369,6 +374,17 @@
       "settings": [
         { "type": "text", "id": "tab", "label": "Tab title", "default": "General Questions" },
         { "type": "image_picker", "id": "tab_icon", "label": "Tab icon" },
+        {
+          "type": "select",
+          "id": "tab_display",
+          "label": "Show",
+          "options": [
+            { "value": "both", "label": "Title and icon" },
+            { "value": "title", "label": "Title only" },
+            { "value": "image", "label": "Icon only" }
+          ],
+          "default": "both"
+        },
         { "type": "text", "id": "question", "label": "Question", "default": "Sample question?" },
         { "type": "richtext", "id": "answer", "label": "Answer", "default": "<p>Sample answer content goes here.</p>" }
       ]

--- a/sections/section-faq-tabs.liquid
+++ b/sections/section-faq-tabs.liquid
@@ -2,6 +2,8 @@
   assign bg_color = section.settings.bg_color
   assign text_color = section.settings.text_color
   assign animation_anchor = '#FaqTabs--' | append: section.id
+  assign tab_icon_size = section.settings.tab_icon_size | default: 32
+  assign tab_icon_size_2x = tab_icon_size | times: 2
 
   assign tabs_string = ''
   for block in section.blocks
@@ -23,6 +25,7 @@
       --card-bg: #fff;
       --card-radius: 14px;
       --tab-accent: #1d6a3a;
+      --tab-icon-size: {{ tab_icon_size }}px;
       --muted: #6b7280;
       --heading-font-family: {{ section.settings.heading_font.family }}, {{ section.settings.heading_font.fallback_families }};
       --heading-font-weight: {{ section.settings.heading_font.weight }};
@@ -95,8 +98,8 @@
       gap: 6px;
     }
     #FaqTabs--{{ section.id }} .faq-tabs__head .tab-link__icon{
-      width: 20px;
-      height: 20px;
+      width: var(--tab-icon-size);
+      height: var(--tab-icon-size);
     }
     #FaqTabs--{{ section.id }} .faq-tabs__head .tab-link.current{ color: #0f172a; }
     #FaqTabs--{{ section.id }} .faq-tabs__head .tab-link.current::after{
@@ -217,7 +220,7 @@
                 aria-controls="panel-{{ section.id }}-{{ forloop.index0 }}"
                 tabindex="0">
                 {%- if tab_display != 'title' and tab_icon != blank -%}
-                  <img class="tab-link__icon" src="{{ tab_icon | image_url: width: 24 }}" alt="{{ tab | escape }}">
+                  <img class="tab-link__icon" src="{{ tab_icon | image_url: width: tab_icon_size_2x }}" alt="{{ tab | escape }}">
                 {%- endif -%}
                 {%- if tab_display != 'image' and tab != blank -%}
                   <span>{{ tab }}</span>
@@ -365,7 +368,8 @@
     { "type": "font_picker", "id": "heading_font", "label": "Heading font", "default": "poppins_n7" },
     { "type": "range", "id": "heading_font_size", "min": 16, "max": 80, "step": 1, "unit": "px", "label": "Heading font size", "default": 32 },
     { "type": "font_picker", "id": "question_font", "label": "Question font", "default": "poppins_n5" },
-    { "type": "range", "id": "question_font_size", "min": 12, "max": 40, "step": 1, "unit": "px", "label": "Question font size", "default": 16 }
+    { "type": "range", "id": "question_font_size", "min": 12, "max": 40, "step": 1, "unit": "px", "label": "Question font size", "default": 16 },
+    { "type": "range", "id": "tab_icon_size", "min": 16, "max": 64, "step": 1, "unit": "px", "label": "Tab icon size", "default": 32 }
   ],
   "blocks": [
     {

--- a/sections/section-faq-tabs.liquid
+++ b/sections/section-faq-tabs.liquid
@@ -4,13 +4,16 @@
   assign animation_anchor = '#FaqTabs--' | append: section.id
 
   assign tabs_string = ''
+  assign icons_string = ''
   for block in section.blocks
     assign t = block.settings.tab | strip
     unless tabs_string contains t
       assign tabs_string = tabs_string | append: t | append: '||'
+      assign icons_string = icons_string | append: block.settings.tab_icon | append: '||'
     endunless
   endfor
   assign tabs = tabs_string | split: '||' | compact
+  assign tab_icons = icons_string | split: '||'
 -%}
 
 {%- if section.blocks.size > 0 -%}
@@ -22,7 +25,6 @@
       --PB: {{ section.settings.padding_bottom }}px;
       --card-bg: #fff;
       --card-radius: 14px;
-      --card-shadow: 0 1px 0 rgba(0,0,0,.04), 0 6px 16px rgba(0,0,0,.06);
       --tab-accent: #1d6a3a;
       --muted: #6b7280;
       --heading-font-family: {{ section.settings.heading_font.family }}, {{ section.settings.heading_font.fallback_families }};
@@ -91,6 +93,13 @@
       outline: none;
       transition: color .2s ease;
       white-space: nowrap;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    #FaqTabs--{{ section.id }} .faq-tabs__head .tab-link__icon{
+      width: 20px;
+      height: 20px;
     }
     #FaqTabs--{{ section.id }} .faq-tabs__head .tab-link.current{ color: #0f172a; }
     #FaqTabs--{{ section.id }} .faq-tabs__head .tab-link.current::after{
@@ -122,7 +131,6 @@
     #FaqTabs--{{ section.id }} details.accordion{
       background: var(--card-bg);
       border-radius: var(--card-radius);
-      box-shadow: var(--card-shadow);
       overflow: hidden;
     }
     #FaqTabs--{{ section.id }} summary.accordion__title{
@@ -202,7 +210,13 @@
                 aria-selected="{% if forloop.first %}true{% else %}false{% endif %}"
                 aria-controls="panel-{{ section.id }}-{{ forloop.index0 }}"
                 tabindex="0">
-                <span>{{ tab }}</span>
+                {%- assign tab_icon = tab_icons[forloop.index0] -%}
+                {%- if tab_icon != blank -%}
+                  <img class="tab-link__icon" src="{{ tab_icon | image_url: width: 24 }}" alt="{{ tab | escape }}">
+                {%- endif -%}
+                {%- if tab != blank -%}
+                  <span>{{ tab }}</span>
+                {%- endif -%}
               </li>
             {%- endfor -%}
           </ul>
@@ -354,6 +368,7 @@
       "name": "Question",
       "settings": [
         { "type": "text", "id": "tab", "label": "Tab title", "default": "General Questions" },
+        { "type": "image_picker", "id": "tab_icon", "label": "Tab icon" },
         { "type": "text", "id": "question", "label": "Question", "default": "Sample question?" },
         { "type": "richtext", "id": "answer", "label": "Answer", "default": "<p>Sample answer content goes here.</p>" }
       ]


### PR DESCRIPTION
## Summary
- remove card drop shadow from FAQ tab accordion items
- support optional image icons alongside FAQ tab titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b143169f048332901443fa98518719